### PR TITLE
Reject setEncryptionKey promise in case of error

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -267,7 +267,7 @@ The <dfn method for="SFrameTransform">setEncryptionKey(|key|, |keyID|)</dfn> met
 1. Let |promise| be [=a new promise=].
 2.  [=In parallel=], run the following steps:
     1. Set |key| with its optional |keyID| as key material to use for the SFrame transform algorithm, as defined by the <a href="https://datatracker.ietf.org/doc/draft-omara-sframe/">SFrame specification</a>.
-    2. If setting the key material fails, [=Reject=] |promise| with an {{InvalidModificationError}} error  and abort these steps.
+    2. If setting the key material fails, [=Reject=] |promise| with an {{InvalidModificationError}} error and abort these steps.
     3. [=Resolve=] |promise| with undefined.
 3. Return |promise|.
 

--- a/index.bs
+++ b/index.bs
@@ -267,7 +267,8 @@ The <dfn method for="SFrameTransform">setEncryptionKey(|key|, |keyID|)</dfn> met
 1. Let |promise| be [=a new promise=].
 2.  [=In parallel=], run the following steps:
     1. Set |key| with its optional |keyID| as key material to use for the SFrame transform algorithm, as defined by the <a href="https://datatracker.ietf.org/doc/draft-omara-sframe/">SFrame specification</a>.
-    2. [=Resolve=] |promise| with undefined.
+    2. If setting the key material fails, [=Reject=] |promise| with an {{InvalidModificationError}} error  and abort these steps.
+    3. [=Resolve=] |promise| with undefined.
 3. Return |promise|.
 
 


### PR DESCRIPTION
Fixes https://github.com/w3c/webrtc-insertable-streams/issues/56


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/webrtc-insertable-streams/pull/57.html" title="Last updated on Feb 18, 2021, 3:37 PM UTC (28d57a9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-insertable-streams/57/b77c4e1...youennf:28d57a9.html" title="Last updated on Feb 18, 2021, 3:37 PM UTC (28d57a9)">Diff</a>