### PR TITLE
Fix errors from partial interface DedicatedWorkerGlobalScope

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -277,8 +277,7 @@ interface RTCTransformEvent : Event {
     readonly attribute RTCRtpScriptTransformer transformer;
 };
 
-[Global=(Worker,DedicatedWorker),Exposed=DedicatedWorker]
-partial interface DedicatedWorkerGlobalScope : WorkerGlobalScope {
+partial interface DedicatedWorkerGlobalScope {
     attribute EventHandler onrtctransform;
 };
 


### PR DESCRIPTION
`: inheritance` part in a partial interface is a syntax error and `[Global]` on a partial interface is a semantics error. Having `[Exposed]` is not an error but is redundant.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/saschanaz/webrtc-insertable-streams/pull/70.html" title="Last updated on Mar 5, 2021, 11:57 PM UTC (5734b44)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-insertable-streams/70/85be2c6...saschanaz:5734b44.html" title="Last updated on Mar 5, 2021, 11:57 PM UTC (5734b44)">Diff</a>