### PR TITLE
Detect missing references on build

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -15,3 +15,4 @@ jobs:
           GH_PAGES_BRANCH: gh-pages
           W3C_WG_DECISION_URL: "https://lists.w3.org/Archives/Public/public-webrtc/2016Mar/0031.html"
           VALIDATE_LINKS: false
+          BUILD_FAIL_ON: link-error

--- a/index.bs
+++ b/index.bs
@@ -13,6 +13,9 @@ Abstract: This API defines an API surface for manipulating the bits on
 Abstract: {{MediaStreamTrack}}s being sent via an {{RTCPeerConnection}}.
 Markup Shorthands: css no, markdown yes
 </pre>
+<pre class=link-defaults>
+spec:webidl; type:dfn; text:resolve
+</pre>
 <pre class=biblio>
 {
   "WEB-CODECS": {


### PR DESCRIPTION
Using spec-prod configuration to detect when the spec uses undefined references https://github.com/w3c/spec-prod/blob/main/docs/options.md#build_fail_on
Per https://github.com/w3c/webrtc-insertable-streams/pull/73#issuecomment-792653932


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-insertable-streams/pull/74.html" title="Last updated on Mar 11, 2021, 5:20 PM UTC (f8e7806)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-insertable-streams/74/11c8f9f...f8e7806.html" title="Last updated on Mar 11, 2021, 5:20 PM UTC (f8e7806)">Diff</a>