### PR TITLE
Fix SFrameTransportOptions typo

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -194,7 +194,7 @@ The <dfn constructor for="SFrameTransform" lt="SFrameTransform(options)"><code>n
 1. Let |transformAlgorithm| be an algorithm which takes a |frame| as input and runs the <a href="#sframe-transform-algorithm">SFrame transform algorithm</a> with |this| and |frame|.
 2. Set |this|.`[[transform]]` to the result of [=TransformStream/creating=] a {{TransformStream}}, with [=TransformStream/create/transformAlgorithm=] set to |transformAlgorithm|.
 3. Let |options| be the method's first argument.
-4. Set |this|.`[[role]]` to |options|["{{SFrameTransportOptions/role}}"].
+4. Set |this|.`[[role]]` to |options|["{{SFrameTransformOptions/role}}"].
 5. Set |this|.`[[readable]]` to |this|.`[[transform]]`.`[[readable]]`.
 6. Set |this|.`[[writable]]` to |this|.`[[transform]]`.`[[writable]]`.
 


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/webrtc-insertable-streams/pull/75.html" title="Last updated on Mar 8, 2021, 10:53 AM UTC (22a47be)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-insertable-streams/75/45d6fb6...youennf:22a47be.html" title="Last updated on Mar 8, 2021, 10:53 AM UTC (22a47be)">Diff</a>