### PR TITLE
Replace DedicatedWorker by Worker for now and remove global which is wrong as well

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -188,6 +188,7 @@ dictionary SFrameTransformOptions {
     SFrameTransformRole role = "encrypt";
 };
 
+// FIXME: We plan to expose only in dedicated worker scopes, but may want to discuss extending it in other contexts.
 [Exposed=(Window,Worker)]
 interface SFrameTransform {
     constructor(optional SFrameTransformOptions options = {});
@@ -278,6 +279,7 @@ interface RTCEncodedAudioFrame {
 
 // New interfaces to expose JavaScript-based transforms.
 
+// FIXME: We want to expose only in dedicated worker scopes.
 [Exposed=Worker]
 interface RTCTransformEvent : Event {
     readonly attribute RTCRtpScriptTransformer transformer;
@@ -287,6 +289,7 @@ partial interface DedicatedWorkerGlobalScope {
     attribute EventHandler onrtctransform;
 };
 
+// FIXME: We want to expose only in dedicated worker scopes.
 [Exposed=Worker]
 interface RTCRtpScriptTransformer {
     readonly attribute ReadableStream readable;

--- a/index.bs
+++ b/index.bs
@@ -188,7 +188,7 @@ dictionary SFrameTransformOptions {
     SFrameTransformRole role = "encrypt";
 };
 
-[Exposed=(Window,DedicatedWorker)]
+[Exposed=(Window,Worker)]
 interface SFrameTransform {
     constructor(optional SFrameTransformOptions options = {});
     Promise<undefined> setEncryptionKey(CryptoKey key, optional unsigned long long keyID);
@@ -278,7 +278,7 @@ interface RTCEncodedAudioFrame {
 
 // New interfaces to expose JavaScript-based transforms.
 
-[Global=(Worker,DedicatedWorker),Exposed=DedicatedWorker]
+[Exposed=Worker]
 interface RTCTransformEvent : Event {
     readonly attribute RTCRtpScriptTransformer transformer;
 };
@@ -287,14 +287,14 @@ partial interface DedicatedWorkerGlobalScope {
     attribute EventHandler onrtctransform;
 };
 
-[Global=(Worker,DedicatedWorker),Exposed=DedicatedWorker]
+[Exposed=Worker]
 interface RTCRtpScriptTransformer {
     readonly attribute ReadableStream readable;
     readonly attribute WritableStream writable;
     readonly attribute any options;
 };
 
-[Exposed=(Window)]
+[Exposed=Window]
 interface RTCRtpScriptTransform {
     constructor(Worker worker, optional any options);
     // FIXME: add messaging methods.


### PR DESCRIPTION
For the sake of landing https://github.com/w3c/webrtc-insertable-streams/pull/74, I am removing DedicatedWorker for now.
We should probably revert part of the changes in the future since RTCTransformEvent does only make sense in DedicatedWorker but this can be done as a follow-up after #74.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/webrtc-insertable-streams/pull/78.html" title="Last updated on Mar 11, 2021, 5:16 PM UTC (0e77fbb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-insertable-streams/78/eac51f0...youennf:0e77fbb.html" title="Last updated on Mar 11, 2021, 5:16 PM UTC (0e77fbb)">Diff</a>