### PR TITLE
Expose RTCEncodedAudioFrame and RTCEncodedVideoFrame in DedicatedWorker contexts

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -259,7 +259,7 @@ dictionary RTCEncodedVideoFrameMetadata {
 
 // New interfaces to define encoded video and audio frames. Will eventually
 // re-use or extend the equivalent defined in WebCodecs.
-[Exposed=Window]
+[Exposed=(Window,DedicatedWorker)]
 interface RTCEncodedVideoFrame {
     readonly attribute RTCEncodedVideoFrameType type;
     readonly attribute unsigned long long timestamp;
@@ -272,7 +272,7 @@ dictionary RTCEncodedAudioFrameMetadata {
     sequence&lt;long&gt; contributingSources;
 };
 
-[Exposed=Window]
+[Exposed=(Window,DedicatedWorker)]
 interface RTCEncodedAudioFrame {
     readonly attribute unsigned long long timestamp;
     attribute ArrayBuffer data;


### PR DESCRIPTION
Fixes https://github.com/w3c/webrtc-insertable-streams/issues/25


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/webrtc-insertable-streams/pull/81.html" title="Last updated on Mar 11, 2021, 6:27 PM UTC (ab4f208)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-insertable-streams/81/0f203e1...youennf:ab4f208.html" title="Last updated on Mar 11, 2021, 6:27 PM UTC (ab4f208)">Diff</a>